### PR TITLE
Turn on browser synchronisation in protractor if the app includes angular

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules/
 reports/
 temp-test/
 log/
+.idea

--- a/lib/buildTool/protractor/testBrowser/templates/protractor.conf.js.tpl
+++ b/lib/buildTool/protractor/testBrowser/templates/protractor.conf.js.tpl
@@ -58,9 +58,10 @@ var config = {
 
 
   onPrepare: function() {
+    <% if (buildJS.framework[0] && buildJS.framework[0].toLowerCase().search('angular') === -1) { %>
     // Turn off the angular-sync part-of-Protractor, as we are using Protractor in a generic way
     browser.ignoreSynchronization = true;
-
+    <% } %>
     return browser.getProcessedConfig().then(function(config) {
       // Attach the reporters
       config.reportWriters.forEach(function(fn) {

--- a/lib/buildTool/protractor/testBrowser/templates/protractor.conf.js.tpl
+++ b/lib/buildTool/protractor/testBrowser/templates/protractor.conf.js.tpl
@@ -58,8 +58,10 @@ var config = {
 
 
   onPrepare: function() {
-    <% if (buildJS.framework[0] && buildJS.framework[0].toLowerCase().search('angular') === -1) { %>
-    // Turn off the angular-sync part-of-Protractor, as we are using Protractor in a generic way
+    <% if (buildJS.framework[0] && buildJS.framework[0].toLowerCase().search('angular') > -1) { %>
+    // Turn on the Angular-sync part-of-Protractor when using Protractor
+    browser.ignoreSynchronization = false;
+    <% } else { %>
     browser.ignoreSynchronization = true;
     <% } %>
     return browser.getProcessedConfig().then(function(config) {

--- a/lib/buildTool/protractor/testBrowser/templates/protractor.conf.js.tpl
+++ b/lib/buildTool/protractor/testBrowser/templates/protractor.conf.js.tpl
@@ -58,12 +58,10 @@ var config = {
 
 
   onPrepare: function() {
-    <% if (buildJS.framework[0] && buildJS.framework[0].toLowerCase().search('angular') > -1) { %>
-    // Turn on the Angular-sync part-of-Protractor when using Protractor
-    browser.ignoreSynchronization = false;
-    <% } else { %>
-    browser.ignoreSynchronization = true;
-    <% } %>
+    <% var ignoreSync = !(buildJS.framework[0] && buildJS.framework[0].search('AngularJS 1.x') > -1); %>
+    // Turn off the Angular-sync part-of-Protractor when not using AngularJS 1.x
+    browser.ignoreSynchronization = <%= ignoreSync %>;
+
     return browser.getProcessedConfig().then(function(config) {
       // Attach the reporters
       config.reportWriters.forEach(function(fn) {

--- a/lib/core/packages.yml
+++ b/lib/core/packages.yml
@@ -82,7 +82,7 @@ $packages:
 
   - &pkg_commitizen
     name: commitizen
-    version: 2.8.1
+    version: 2.8.2
     global: true
 
   - &pkg_core-js


### PR DESCRIPTION
The browser synchronization of protractor is useful for an angular app so we disable it only if the
project is not an angular one.

ISSUES CLOSED: #61

fix/protractor-sync-angular