### PR TITLE
fix(build): webpack htmlLoader supports .htm and .html file extensions

### DIFF
--- a/docs/content/architecture.md
+++ b/docs/content/architecture.md
@@ -102,13 +102,11 @@ CSS-tool generator.
 ### buildHTML [render badge list="browser"]
 
 #### Questions
-
-**HTML source file extension?** [**.html**, .htm] `buildHTML.extension`
-- This question is designed to support other HTML source code formats (e.g. Jade) in the future.
+None
 
 #### Build Tools
 <ul>
-<li><div class="{$ styles.badge__webpack $}"></div> build tool generates Webpack loaders for the chosen HTML extension and also the `index.html` template file.</li>
+<li><div class="{$ styles.badge__webpack $}"></div> build tool generates Webpack loaders for HTML files (`.htm` and `.html` extensions) and also the `index.html` template file.</li>
 </ul>
 
 ---

--- a/lib/buildTool/webpack/buildHTML/templates/webpack.buildHTML.config.js.tpl
+++ b/lib/buildTool/webpack/buildHTML/templates/webpack.buildHTML.config.js.tpl
@@ -13,7 +13,7 @@
 
 
   let htmlLoader = {
-    test: /\<%= buildHTML.extension %>$/,
+    test: /\.html?$/,
     use: [
       {
         loader: 'html-loader'

--- a/lib/generators/buildHTML/index.js
+++ b/lib/generators/buildHTML/index.js
@@ -1,41 +1,4 @@
 'use strict';
 let confitGen = require('../../core/ConfitGenerator.js');
 
-module.exports = confitGen.create({
-
-  prompting: function() {
-    if (this.rebuildFromConfig) {
-      return;
-    }
-
-    this.displayTitle('Build HTML Generator');
-
-    let resources = this.getResources().buildHTML;
-    let genDefaults = this.merge(resources.defaults, this.getConfig());
-
-    let prompts = [
-      {
-        type: 'list',
-        name: 'extension',
-        message: 'HTML source file extension?',
-        choices: [
-          '.html',
-          '.htm',
-        ],
-        default: genDefaults.extension,
-      },
-    ];
-
-    return this.prompt(prompts).then(function(props) {
-      this.answers = this.generateObjFromAnswers(props);
-    }.bind(this));
-  },
-
-  configuring: function() {
-    // If we have new answers, then change the config
-    if (this.answers) {
-      this.buildTool.configure.apply(this);
-      this.setConfig(this.answers);
-    }
-  },
-});
+module.exports = confitGen.create({});

--- a/lib/projectType/browser/browserResources.yml
+++ b/lib/projectType/browser/browserResources.yml
@@ -179,9 +179,7 @@ buildCSS:
     stylus:
       ext: ['styl']
 
-buildHTML:
-  defaults:
-    extension: .html
+buildHTML: {}
 
 buildJS:
   defaults:

--- a/test/fixtures/0_webpack-ts-ng1-stylus.yml
+++ b/test/fixtures/0_webpack-ts-ng1-stylus.yml
@@ -45,8 +45,7 @@ generator-confit:
     sourceFormat: TypeScript
     vendorScripts: []
   buildHTML:
-    _version: 2d504dda228b29eeca588658d95e1b5f466f2b6f
-    extension: .html
+    _version: 1323fcb6eabaf6e8a432e153dc2c7c2cce334b60
   documentation:
     _version: b1658da3278b16d1982212f5e8bc05348af20e0b
     generateDocs: false

--- a/test/fixtures/0_webpack-ts-ng2-stylus.yml
+++ b/test/fixtures/0_webpack-ts-ng2-stylus.yml
@@ -46,7 +46,7 @@ generator-confit:
     sourceFormat: TypeScript
     vendorScripts: []
   buildHTML:
-    _version: 2d504dda228b29eeca588658d95e1b5f466f2b6f
+    _version: 1323fcb6eabaf6e8a432e153dc2c7c2cce334b60
     extension: .html
   documentation:
     _version: b1658da3278b16d1982212f5e8bc05348af20e0b

--- a/test/fixtures/1_webpack-different-paths.yml
+++ b/test/fixtures/1_webpack-different-paths.yml
@@ -46,7 +46,7 @@ generator-confit:
     sourceFormat: ES6
     vendorScripts: []
   buildHTML:
-    _version: 2d504dda228b29eeca588658d95e1b5f466f2b6f
+    _version: 1323fcb6eabaf6e8a432e153dc2c7c2cce334b60
     extension: .html
   documentation:
     _version: b1658da3278b16d1982212f5e8bc05348af20e0b

--- a/test/fixtures/1_webpack-es6-ng1-stylus.yml
+++ b/test/fixtures/1_webpack-es6-ng1-stylus.yml
@@ -46,8 +46,7 @@ generator-confit:
     vendorScripts:
       - angular
   buildHTML:
-    _version: 2d504dda228b29eeca588658d95e1b5f466f2b6f
-    extension: .html
+    _version: 1323fcb6eabaf6e8a432e153dc2c7c2cce334b60
   documentation:
     _version: b1658da3278b16d1982212f5e8bc05348af20e0b
     createSampleDocs: true

--- a/test/fixtures/1_webpack-es6-none-css.yml
+++ b/test/fixtures/1_webpack-es6-none-css.yml
@@ -44,7 +44,7 @@ generator-confit:
     sourceFormat: ES6
     vendorScripts: []
   buildHTML:
-    _version: 2d504dda228b29eeca588658d95e1b5f466f2b6f
+    _version: 1323fcb6eabaf6e8a432e153dc2c7c2cce334b60
     extension: .htm
   documentation:
     _version: b1658da3278b16d1982212f5e8bc05348af20e0b

--- a/test/fixtures/1_webpack-es6-none-sass.yml
+++ b/test/fixtures/1_webpack-es6-none-sass.yml
@@ -44,7 +44,7 @@ generator-confit:
     sourceFormat: ES6
     vendorScripts: []
   buildHTML:
-    _version: 2d504dda228b29eeca588658d95e1b5f466f2b6f
+    _version: 1323fcb6eabaf6e8a432e153dc2c7c2cce334b60
     extension: .htm
   documentation:
     _version: b1658da3278b16d1982212f5e8bc05348af20e0b

--- a/test/fixtures/1_webpack-es6-none-stylus.yml
+++ b/test/fixtures/1_webpack-es6-none-stylus.yml
@@ -44,7 +44,7 @@ generator-confit:
     sourceFormat: ES6
     vendorScripts: []
   buildHTML:
-    _version: 2d504dda228b29eeca588658d95e1b5f466f2b6f
+    _version: 1323fcb6eabaf6e8a432e153dc2c7c2cce334b60
     extension: .htm
   documentation:
     _version: b1658da3278b16d1982212f5e8bc05348af20e0b

--- a/test/fixtures/1_webpack-es6-react-stylus.yml
+++ b/test/fixtures/1_webpack-es6-react-stylus.yml
@@ -45,7 +45,7 @@ generator-confit:
     sourceFormat: ES6
     vendorScripts: []
   buildHTML:
-    _version: 2d504dda228b29eeca588658d95e1b5f466f2b6f
+    _version: 1323fcb6eabaf6e8a432e153dc2c7c2cce334b60
     extension: .html
   documentation:
     _version: b1658da3278b16d1982212f5e8bc05348af20e0b

--- a/test/fixtures/9_webpack-ts-none-stylus.yml
+++ b/test/fixtures/9_webpack-ts-none-stylus.yml
@@ -44,7 +44,7 @@ generator-confit:
     sourceFormat: TypeScript
     vendorScripts: []
   buildHTML:
-    _version: 2d504dda228b29eeca588658d95e1b5f466f2b6f
+    _version: 1323fcb6eabaf6e8a432e153dc2c7c2cce334b60
     extension: .html
   documentation:
     _version: b1658da3278b16d1982212f5e8bc05348af20e0b


### PR DESCRIPTION
Simplified buildHTML generator to no longer prompt for HTML extension type.

ISSUES CLOSED: #105